### PR TITLE
Update Google AdMob version to fix crash on application start for SDK version above 31

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Monetize your apps with KivAds using Google AdMob api.
 
-KivAds uses the latest version of Google AdMob sdk(version 20.0.0). KivAds exposes most of the functions and operations available in the Admob sdk as easy to use python functions, allowing you to quickly integrate ads into your app. So far in testing KivAds works 100% reliabily on devices from android 6 all the way upto android 11.
+KivAds uses the latest version of Google AdMob sdk(version 22.5.0). KivAds exposes most of the functions and operations available in the Admob sdk as easy to use python functions, allowing you to quickly integrate ads into your app. So far in testing KivAds works 100% reliabily on devices from android 6 all the way upto android 13.
 
 ## Important Info
 
@@ -40,7 +40,7 @@ KivAds requires some changes to your buildozer.spec file and also python-for-and
 to `distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 `
 
-    I am still testing other gradle versions to see if they will work with KivAds.
+    I am still testing other gradle versions to see if they will work with KivAds. This change might be unnecessary for recent versions of Python for Android.
 
 3. Now change the following fields in your `buildozer.spec` file.
 `android.permissions`,
@@ -50,8 +50,8 @@ to `distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zi
     to this
     ```
     android.permissions = INTERNET, ACCESS_NETWORK_STATE
-    android.api = 30 # Anything 28 and above is okay
-    android.gradle_dependencies = 'com.google.android.gms:play-services-ads:20.3.0'
+    android.api = 34 # Anything 28 and above is okay
+    android.gradle_dependencies = 'com.google.android.gms:play-services-ads:22.5.0'
     ```
 
 4. Now you need to add your admob app-id to the manifest file in order for ads to work in your app. Change the `android.meta_data`

--- a/demo/buildozer.spec
+++ b/demo/buildozer.spec
@@ -98,7 +98,7 @@ android.permissions = NTERNET, ACCESS_NETWORK_STATE
 #android.features = android.hardware.usb.host
 
 # (int) Target Android API, should be as high as possible.
-android.api = 30
+android.api = 34
 
 # (int) Minimum API your APK / AAB will support.
 #android.minapi = 21
@@ -180,7 +180,7 @@ android.add_src = src
 #android.add_aars =
 
 # (list) Gradle dependencies to add
-android.gradle_dependencies = "com.google.android.gms:play-services-ads:20.3.0"
+android.gradle_dependencies = com.google.android.gms:play-services-ads:22.5.0
 
 # (bool) Enable AndroidX support. Enable when 'android.gradle_dependencies'
 # contains an 'androidx' package, or any package from Kotlin source.


### PR DESCRIPTION
- change Google AdMob version from 20.3.0 to 22.5.0 in the spec file which fixes #6 
- remove quotation marks around com.google.android.gms:play-services-ads:22.5.0 which causes errors with latest buildozer versions
- change Google AdMob version from 20.3.0 to 22.5.0 in the readme instructions